### PR TITLE
render string to matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # FreeTypeAbstraction
 
-Easily load and render Fonts:
+Draw text into a Matrix.
 
 ```Julia
 
-using FreeTypeAbstraction, StaticArrays
-using Base.Test
+using FreeTypeAbstraction
 
-# write your own tests here
+# load a font
 face = newface("hack_regular.ttf")
 
+# render a character
 img, metric = renderface(face, 'C')
-@test size(img) == (15, 23)
-@test typeof(img) == Array{UInt8,2}
-@test metric == FontExtent(
-	MVector(-8,4),
-	MVector(2,23),
-	MVector(19,31),
-	MVector(15,23)
-)
+
+# render a string into an existing matrix
+myarray = zeros(UInt8,100,100)
+renderstring(myarray, "hello", face, (10,10), 90, 10, halign=:hright)
 ```
 
 credits to @aaalexandrov from whom most of the code stems.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.5
 FreeType
 StaticArrays
+Colors
+ColorVectorSpace

--- a/src/FreeTypeAbstraction.jl
+++ b/src/FreeTypeAbstraction.jl
@@ -2,7 +2,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module FreeTypeAbstraction
 
-using FreeType, StaticArrays
+using FreeType, StaticArrays, Colors, ColorVectorSpace
 
 include("functions.jl")
 
@@ -10,6 +10,7 @@ export newface
 export renderface
 export FontExtent
 export kerning
+export renderstring!
 
 function __init__()
     ft_init()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
-using FreeTypeAbstraction, StaticArrays
+using FreeTypeAbstraction, StaticArrays, Colors, ColorVectorSpace
 using Base.Test
 
-# write your own tests here
 face = newface("hack_regular.ttf")
 
 img, metric = renderface(face, 'C')
@@ -13,3 +12,51 @@ img, metric = renderface(face, 'C')
 	MVector(19,31),
 	MVector(15,23)
 )
+
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 10)
+@test any(a[3:12,:].!=0)
+@test all(a[vcat(1:2,13:20),:].==0)
+@test any(a[:,11:40].!=0)
+@test all(a[:,vcat(1:10,41:100)].==0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 15, 70)
+@test any(a[8:17,:].!=0)
+@test all(a[vcat(1:7,18:20),:].==0)
+@test any(a[:,71:100].!=0)
+@test all(a[:,1:70].==0)
+
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, valign=:vtop)
+@test all(a[1:10,:].==0)
+@test any(a[11:20,:].!=0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, valign=:vcenter)
+@test all(a[vcat(1:5,16:end),:].==0)
+@test any(a[6:15,:].!=0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, valign=:vbaseline)
+@test all(a[vcat(1:2,13:end),:].==0)
+@test any(a[3:12,:].!=0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, valign=:vbottom)
+@test any(a[1:10,:].!=0)
+@test all(a[11:20,:].==0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, halign=:hleft)
+@test all(a[:,1:50].==0)
+@test any(a[:,51:100].!=0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, halign=:hcenter)
+@test all(a[:,vcat(1:35,66:end)].==0)
+@test any(a[:,36:65].!=0)
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, halign=:hright)
+@test any(a[:,1:50].!=0)
+@test all(a[:,51:100].==0)
+
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, fcolor=0x80)
+@test maximum(a)<=0x80
+a = renderstring!(zeros(UInt8,20,100), "helgo", face, (10,10), 10, 50, fcolor=0x80, bcolor=0x40)
+@test any(a.==0x40)
+a = renderstring!(fill(0x01,20,100), "helgo", face, (10,10), 10, 50, bcolor=nothing)
+@test !any(a.==0x00)
+
+a = renderstring!(zeros(Float32,20,100), "helgo", face, (10,10), 10, 50)
+@test maximum(a)<=1.0
+a = renderstring!(zeros(Float64,20,100), "helgo", face, (10,10), 10, 50)
+@test maximum(a)<=1.0
+
+a = renderstring!(zeros(Gray,20,100), "helgo", face, (10,10), 10, 50)
+a = renderstring!(zeros(Gray{Float64},20,100), "helgo", face, (10,10), 10, 50, fcolor=Gray(0.5))


### PR DESCRIPTION
this PR adds and exports `renderstring`, which inputs a matrix and renders a string of a given font and size at a specified location.  a few things to consider:

1. the other two PRs need to be merged first, then i'll clean this one up

2. what is the best coordinate frame?  currently, i use the upper left corner as the origin, and use the nomenclature x,y, with positive y going down

3. should we rename this package to ImageText?

4. at some point it'd be nice if the FreeTypeAbstraction module was excised from GLVisualize and a dependency to this package was added to the latter.

5. should we add some fonts like in GLVisualize?  if not, we should at least document where to find them.

6.  at some point we should also register this package.