### PR TITLE
Fix loading of font assets

### DIFF
--- a/src/findfonts.jl
+++ b/src/findfonts.jl
@@ -8,7 +8,7 @@ if Sys.isapple()
         ]
     end
 elseif Sys.iswindows()
-    _font_paths() = [joinpath(ENV["WINDIR"], "fonts")]
+    _font_paths() = [joinpath(ENV["SYSTEMROOT"], "fonts")]
 else
     function add_recursive(result, path)
         for p in readdir(path)

--- a/src/findfonts.jl
+++ b/src/findfonts.jl
@@ -8,7 +8,7 @@ if Sys.isapple()
         ]
     end
 elseif Sys.iswindows()
-    _font_paths() = [joinpath(ENV["SYSTEMROOT"], "fonts")]
+    _font_paths() = [joinpath(get(ENV, "SYSTEMROOT", "C:\\Windows"), "Fonts")]
 else
     function add_recursive(result, path)
         for p in readdir(path)

--- a/src/findfonts.jl
+++ b/src/findfonts.jl
@@ -84,7 +84,7 @@ end
 function findfont(name::String; italic = false, bold = false, additional_fonts::String = "")
     font_folders = copy(fontpaths())
     normalized_name = family_name(name)
-    isempty(additional_fonts) || push!(font_folders, additional_fonts)
+    isempty(additional_fonts) || pushfirst!(font_folders, additional_fonts)
     candidates = Ptr{FreeType.FT_FaceRec}[]
     for folder in font_folders
         for font in readdir(folder)


### PR DESCRIPTION
I think the font loading logic is kinda borked since I have DejaVu Sans fonts installed  by default  but FreeTypeAbstraction pulls in  the slanted bold version instead.

What this PR changes is to first search the `additional_folders` before the default font  folders   to locate  the font. The following `pop` operation then pulls in the correct version. 

This fixes the strange default font when using Makie.

