### PR TITLE
change match_fonts so it heuristically chooses the best font by full name 

### DIFF
--- a/src/findfonts.jl
+++ b/src/findfonts.jl
@@ -39,15 +39,38 @@ function style_name(x::FTFont)
     lowercase(x.style_name)
 end
 
-function match_font(face::FTFont, name, italic, bold)
+"""
+Match a font using the user-specified search string, by increasing the score
+for each part that appears in the font family + style name, and decreasing it
+for each part that doesn't. The function also prefers shorter font names when
+encountering similar scores.
+"""
+function match_font(face::FTFont, searchstring)
     fname = family_name(face)
     sname = style_name(face)
-    italic = italic == (sname == "italic")
-    bold = bold == (sname == "bold")
-    perfect_match = (fname == name) && italic && bold
-    fuzzy_match = occursin(name, fname)
-    score = fuzzy_match + bold + italic
-    return perfect_match, fuzzy_match, score
+    full_name = "$fname $sname"
+    # \W splits at all groups of non-word characters (like space, -, ., etc)
+    searchparts = unique(split(lowercase(searchstring), r"\W+", keepempty=false))
+    # count letters of parts that occurred in the font name positively and those that didn't negatively.
+    # we assume that the user knows at least parts of the name and doesn't misspell them
+    # but they might not know the exact name, especially for long font names, or they
+    # might simply not want to be forced to spell it out completely.
+    # therefore we let each part we can find count towards a font, and each that
+    # doesn't match against it, therefore rejecting fonts that mismatch more parts
+    # than they match. this heuristic should be good enough to provide a hassle-free
+    # font selection experience where most spellings that are expected to work, work.
+    match_score = sum(map(part -> sign(occursin(part, full_name)) * length(part), searchparts))
+    # give shorter font names that matched equally well a higher score after the decimal point.
+    # this should usually pick the "standard" variant of a font as long as it
+    # doesn't have a special identifier like "regular", "roman", "book", etc.
+    # to be fair, with these fonts the old fontconfig method also often fails because
+    # it's not clearly defined what the most normal version is for the user.
+    # it's therefore better to just have them specify these parts of the name that
+    # they think are important. this is especially important for attributes that
+    # fall outside of the standard italic / bold distinction like "condensed",
+    # "semibold", "oblique", etc.
+    final_score = match_score + (1.0 / length(full_name))
+    return final_score
 end
 
 function try_load(fpath)
@@ -60,22 +83,24 @@ end
 
 function findfont(
         name::String;
-        italic::Bool=false, bold::Bool=false, additional_fonts::String=""
+        italic::Bool=false, # this is unused in the new implementation
+        bold::Bool=false, # and this as well
+        additional_fonts::String=""
     )
     font_folders = copy(fontpaths())
-    normalized_name = family_name(name)
+    # normalized_name = family_name(name)
     isempty(additional_fonts) || pushfirst!(font_folders, additional_fonts)
-    candidates = Pair{FTFont, Int}[]
+
+    candidates = Pair{FTFont, Float64}[]
     for folder in font_folders
         for font in readdir(folder)
             fpath = joinpath(folder, font)
             face = try_load(fpath)
             face === nothing && continue
-            perfect_match, fuzzy_match, score = match_font(
-                face, normalized_name, italic, bold
-            )
-            perfect_match && return face
-            if fuzzy_match
+            score = match_font(face, name)
+
+            # only take results with net positive character matches into account
+            if floor(score) > 0
                 push!(candidates, face => score)
             else
                 finalize(face) # help gc a bit!

--- a/src/findfonts.jl
+++ b/src/findfonts.jl
@@ -44,6 +44,29 @@ Match a font using the user-specified search string, by increasing the score
 for each part that appears in the font family + style name, and decreasing it
 for each part that doesn't. The function also prefers shorter font names when
 encountering similar scores.
+
+
+Example:
+
+If we had only four fonts:
+- Helvetica
+- Helvetica Neue
+- Helvetica Neue Light
+- Times New Roman
+
+Then this is how this function would match different search strings:
+- "helvetica"           => Helvetica
+- "helv"                => Helvetica
+- "HeLvEtIcA"           => Helvetica
+- "helvetica neue"      => Helvetica Neue
+- "tica eue"            => Helvetica Neue
+- "helvetica light"     => Helvetica Neue Light
+- "light"               => Helvetica Neue Light
+- "helvetica bold"      => Helvetica
+- "helvetica neue bold" => Helvetica Neue
+- "times"               => Times New Roman
+- "times new roman"     => Times New Roman
+- "arial"               => no match
 """
 function match_font(face::FTFont, searchstring)
     fname = family_name(face)


### PR DESCRIPTION
This disregards the bold and italic flags, I've kept them so the function doesn't break. But the end user only specifies a string anyway, so they wouldn't even notice this.