### PR TITLE
Fix typos

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -35,7 +35,7 @@ function iterate_extents(f, line::AbstractString, fonts, scales)
     lastpos = 0.0
     for (char, scale, font) in iterator
         extent, glyph_box = metrics_bb(char, font, scale)
-        mini = minimimum(glyph_box) .+ Vec2f0(lastpos, 0.0)
+        mini = minimum(glyph_box) .+ Vec2f0(lastpos, 0.0)
         glyph_box = Rect2D(mini, widths(glyph_box))
         glyph_advance = Point2f0(extent.advance)
         lastpos += glyph_advance[1]
@@ -53,5 +53,5 @@ function glyph_rects(line::AbstractString, fonts, scales)
 end
 
 function boundingbox(line::AbstractString, fonts, scales)
-    reduce(union, glyph_rects(lines, fonts, scales))
+    reduce(union, glyph_rects(line, fonts, scales))
 end


### PR DESCRIPTION
This PR is also an issue-- I hope that's alright.

I'm trying to figure out how to use `boundingbox`; even with these fixes, e.g.
```julia
face= FreeTypeAbstraction.findfont("Times")
FreeTypeAbstraction.boundingbox("abc", face, 1f0)
```
fails with an error
```julia
ERROR: MethodError: no method matching iterate(::FontExtent{Float32})
Closest candidates are:
  iterate(::Core.SimpleVector) at essentials.jl:603
  iterate(::Core.SimpleVector, ::Any) at essentials.jl:603
  iterate(::ExponentialBackOff) at error.jl:253
  ...
Stacktrace:
 [1] _foldl_impl(::Base.BottomRF{typeof(min)}, ::Base._InitialValue, ::FontExtent{Float32}) at ./reduce.jl:53
 [2] foldl_impl(::Base.BottomRF{typeof(min)}, ::NamedTuple{(),Tuple{}}, ::FontExtent{Float32}) at ./reduce.jl:45
 [3] mapfoldl_impl(::typeof(identity), ::typeof(min), ::NamedTuple{(),Tuple{}}, ::FontExtent{Float32}) at ./reduce.jl:41
 [4] mapfoldl(::Function, ::Function, ::FontExtent{Float32}; kw::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./reduce.jl:157
 [5] mapfoldl(::Function, ::Function, ::FontExtent{Float32}) at ./reduce.jl:157
 [6] mapreduce(::Function, ::Function, ::FontExtent{Float32}; kw::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./reduce.jl:283
 [7] mapreduce(::Function, ::Function, ::FontExtent{Float32}) at ./reduce.jl:283
 [8] minimum(::FontExtent{Float32}) at ./reduce.jl:660
 [9] iterate_extents(::FreeTypeAbstraction.var"#24#25"{Array{GeometryTypes.HyperRectangle{2,Float32},1}}, ::String, ::FTFont, ::Float32) at /Users/eh540/.julia/dev/FreeTypeAbstraction/src/layout.jl:38
 [10] glyph_rects at /Users/eh540/.julia/dev/FreeTypeAbstraction/src/layout.jl:49 [inlined]
 [11] boundingbox(::String, ::FTFont, ::Float32) at /Users/eh540/.julia/dev/FreeTypeAbstraction/src/layout.jl:56
 [12] top-level scope at REPL[18]:1
```
Would appreciate any help :)

I'm trying to write a function `(str::String, face::FTFont) -> img::Matrix{UInt8}` where I don't have to know the size ahead of time like with `renderstring!`, and I thought `boundingbox` might help.