### PR TITLE
Make broadcasting over FTFont easier

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -156,6 +156,9 @@ function Base.getproperty(font::FTFont, fieldname::Symbol)
     end
 end
 
+# Allow broadcasting over fonts
+Base.Broadcast.broadcastable(ft::FTFont) = Ref(ft)
+
 get_pixelsize(face::FTFont) = getfield(face, :current_pixelsize)[]
 
 function set_pixelsize(face::FTFont, size::Integer)


### PR DESCRIPTION
With this PR, FTFont is treated as a Ref when broadcasting.  This makes broadcasting in the "one or vector" case significantly easier.