### PR TITLE
Clarify readme example, remove depreciated syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ face = FTFont("hack_regular.ttf")
 img, metric = renderface(face, 'C')
 
 # render a string into an existing matrix
-myarray = zeros(UInt8,100,100)
-renderstring!(myarray, "hello", face, (10,10), 90, 10, halign=:hright)
+myarray = zeros(UInt8, 100, 100)
+fontsize = 10
+x0, y0 = 90, 10
+renderstring!(myarray, "hello", face, fontsize, x0, y0, halign=:hright)
 ```
 
 credits to @aaalexandrov from whom most of the early code comes.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ img, metric = renderface(face, 'C')
 
 # render a string into an existing matrix
 myarray = zeros(UInt8, 100, 100)
-fontsize = 10
+pixelsize = 10
 x0, y0 = 90, 10
-renderstring!(myarray, "hello", face, fontsize, x0, y0, halign=:hright)
+renderstring!(myarray, "hello", face, pixelsize, x0, y0, halign=:hright)
 ```
 
 credits to @aaalexandrov from whom most of the early code comes.


### PR DESCRIPTION
This makes it a little easier to understand the syntax at a glance, and remove the depreciated tuple for font size.