### PR TITLE
add file match to find font()

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The FreeTypeAbstraction.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2015: SimonDanisch and Aaalexandrov.
+> Copyright (c) 2015-2021: SimonDanisch, Aaalexandrov, and contributors.
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ myarray = zeros(UInt8, 100, 100)
 pixelsize = 10
 x0, y0 = 90, 10
 renderstring!(myarray, "hello", face, pixelsize, x0, y0, halign=:hright)
+
+# find fonts
+
+f = findfont("helv bo")
+f.family_name * " " * f.style_name
+# => "Helvetica LT Std Bold"
+
+f = findfont("Ari")
+f.family_name * " " * f.style_name
+# => "Arial Unicode MS Regular"
 ```
 
 credits to @aaalexandrov from whom most of the early code comes.

--- a/src/findfonts.jl
+++ b/src/findfonts.jl
@@ -20,7 +20,7 @@ else
     end
     function _font_paths()
         result = String[]
-	for p in ("/usr/share/fonts", joinpath(homedir(), ".fonts"), joinpath(homedir(), ".local/share/fonts"), "/usr/local/share/fonts",)
+    for p in ("/usr/share/fonts", joinpath(homedir(), ".fonts"), joinpath(homedir(), ".local/share/fonts"), "/usr/local/share/fonts",)
             if isdir(p)
                 push!(result, p)
                 add_recursive(result, p)
@@ -84,10 +84,10 @@ end
 fontname(ft::FTFont) = "$(family_name(ft)) $(style_name(ft))"
 
 """
-	findfont(
-			searchstring::String;
-			additional_fonts::String=""
-		)
+    findfont(
+            searchstring::String;
+            additional_fonts::String=""
+        )
 
 Find a font that matches the specified search string.
 
@@ -149,22 +149,22 @@ function findfont(
     best_score_so_far = (0, 0, false, typemin(Int))
     best_font = nothing
 
-	found = false
+    found = false
 
     for folder in font_folders
         for font in readdir(folder)
             fpath = joinpath(folder, font)
 
-			# look for a file that exactly matches the search string (with or without extension)
-			filefontname, filefontext = splitext(font)
-			if searchstring == font || (searchstring == filefontname && lowercase(filefontext) ∈ (".otf", ".ttf"))
-				face = try_load(fpath)
-	            face === nothing && continue  # not a font
-				best_font = face
-				found = true
-				@debug "found font file $(fpath) to match \"$(searchstring)\""
-				break
-			end
+            # look for a file that exactly matches the search string (with or without extension)
+            filefontname, filefontext = splitext(font)
+            if searchstring == font || (searchstring == filefontname && lowercase(filefontext) ∈ (".otf", ".ttf"))
+                face = try_load(fpath)
+                face === nothing && continue  # not a font
+                best_font = face
+                found = true
+                @debug "found font file $(fpath) to match \"$(searchstring)\""
+                break
+            end
 
             face = try_load(fpath)
             face === nothing && continue
@@ -193,7 +193,7 @@ function findfont(
                 finalize(face)
             end
         end
-		found && break
+        found && break
     end
     best_font
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,18 +194,21 @@ else # windows have some more fonts installed per default
 end
 
 @testset "finding fonts" begin
-
     for font in fonts
         @testset "finding $font" begin
             @test findfont(font) != nothing
         end
+    end
+    @testset "finding font file" begin
+        @test findfont("hack_regular.ttf", additional_fonts =".") != nothing
+        @test findfont("hack_regular",     additional_fonts =".") != nothing
+        @test findfont("hack_regular.otf", additional_fonts =".") == nothing
     end
     @testset "find in additional dir" begin
         @test findfont("Hack") == nothing
         @test findfont("Hack", additional_fonts = @__DIR__) != nothing
     end
 end
-
 
 @testset "loading lots of fonts" begin
     for i = 1:10


### PR DESCRIPTION
Since on Slack I wondered to @jkrumbiegel why this wasn't currently possible, I thought I'd better make an effort and try adding it myself... :) 

The intention is to allow specifying a font by giving a filename. So eg in Makie you can now go:

```
f = Figure()
...
f.scene.attributes[:font] = "BenguiatGothicStd-MediumObl.otf"
```

This doesn't really add very much functionality since Julius' existing font finding stuff is already pretty good, but users might expect that this more basic way of specifying a font would also be possible.

I also moved the docstring to the exported `findfont()` function, not sure whether its more likely to be read there.
