### PR TITLE
`face.glyph` should be used as a pointer instead of a value

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ColorVectorSpace = "0.8"
 Colors = "0.11, 0.12"
-FreeType = "3"
+FreeType = "3, 4"
 GeometryBasics = "0.2, 0.3"
 StaticArrays = "0.12, 1.0"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FreeTypeAbstraction"
 uuid = "663a7486-cb36-511b-a19d-713bb74d65c9"
-version = "0.8.4"
+version = "0.9.0"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
@@ -12,7 +12,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ColorVectorSpace = "0.8"
 Colors = "0.11, 0.12"
-FreeType = "3, 4"
+FreeType = "4"
 GeometryBasics = "0.2, 0.3"
 StaticArrays = "0.12, 1.0"
 julia = "1"

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -7,7 +7,7 @@ end
 function renderface(face::FTFont, c::Char, pixelsize::Integer)
     set_pixelsize(face, pixelsize)
     loadchar(face, c)
-    glyph = face.glyph
+    glyph = unsafe_load(face.glyph)
     @assert glyph.format == FreeType.FT_GLYPH_FORMAT_BITMAP
     return glyphbitmap(glyph.bitmap), FontExtent(glyph.metrics)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -156,9 +156,6 @@ function Base.getproperty(font::FTFont, fieldname::Symbol)
     if field isa Ptr{FT_String}
         field == C_NULL && return ""
         return unsafe_string(field)
-    # Some fields segfault with unsafe_load...Lets find out which another day :D
-    elseif field isa Ptr{FreeType.LibFreeType.FT_GlyphSlotRec}
-        return unsafe_load(field)
     else
         return field
     end
@@ -208,7 +205,7 @@ function internal_get_extent(face::FTFont, char::Char)
     check_error(err, "Could not load char to get extent.")
     # This gives us the font metrics in normalized units (0, 1), with negative
     # numbers interpreted as an offset
-    return FontExtent(face.glyph.metrics, Float32(face.units_per_EM))
+    return FontExtent(unsafe_load(face.glyph).metrics, Float32(face.units_per_EM))
 end
 
 descender(font) = font.descender / font.units_per_EM


### PR DESCRIPTION
Not sure the reason why it was used in this way. I guess the binding for this type generated by old Clang.jl is wrong. Now, this should be fixed by https://github.com/JuliaGraphics/FreeType.jl/pull/41 with Clang.jl's new generator.