### PR TITLE
Replace Vec2f0 with Vec2f, FRect2D with Rect2f, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ColorVectorSpace = "0.8, 0.9"
 Colors = "0.11, 0.12"
 FreeType = "4"
-GeometryBasics = "0.2, 0.3"
+GeometryBasics = "0.4.1"
 StaticArrays = "0.12, 1.0"
 julia = "1"
 

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -6,9 +6,9 @@ iter_or_array(x::StaticArray) = repeated(x)
 
 
 function metrics_bb(char::Char, font::FTFont, pixel_size)
-    extent = get_extent(font, char) .* Vec2f0(pixel_size)
+    extent = get_extent(font, char) .* Vec2f(pixel_size)
     mini = bearing(extent)
-    return Rect2D(mini, Vec2f0(extent.scale)), extent
+    return Rect2(mini, Vec2f(extent.scale)), extent
 end
 
 function boundingbox(char::Char, font::FTFont, pixel_size)
@@ -28,7 +28,7 @@ Newlines will be drawn like any other character.
 `fonts` can be a vector of fonts, or a single font.
 `scales` can be a single float or a Vec2, or a vector of any of those.
 
-`f` will get called with `(char::Char, glyph_box::Rec2D, glyph_advance::Point2f0)`.
+`f` will get called with `(char::Char, glyph_box::Rec2D, glyph_advance::Point2f)`.
 
 `char` is the currently iterated char.
 
@@ -43,16 +43,16 @@ function iterate_extents(f, line::AbstractString, fonts, scales)
     lastpos = 0.0
     for (char, scale, font) in iterator
         glyph_box, extent = metrics_bb(char, font, scale)
-        mini = minimum(glyph_box) .+ Vec2f0(lastpos, 0.0)
-        glyph_box = Rect2D(mini, widths(glyph_box))
-        glyph_advance = Point2f0(extent.advance)
+        mini = minimum(glyph_box) .+ Vec2f(lastpos, 0.0)
+        glyph_box = Rect2(mini, widths(glyph_box))
+        glyph_advance = Point2f(extent.advance)
         lastpos += glyph_advance[1]
         f(char, glyph_box, glyph_advance)
     end
 end
 
 function glyph_rects(line::AbstractString, fonts, scales)
-    rects = Rect2D[]
+    rects = Rect2[]
     iterate_extents(line, fonts, scales) do char, box, advance
         push!(rects, box)
     end
@@ -68,7 +68,7 @@ function inkboundingbox(ext::FontExtent)
     r = rightinkbound(ext)
     b = bottominkbound(ext)
     t = topinkbound(ext)
-    return FRect2D((l, b), (r - l, t - b))
+    return Rect2f((l, b), (r - l, t - b))
 end
 
 function height_insensitive_boundingbox(ext::FontExtent, font::FTFont)
@@ -76,5 +76,5 @@ function height_insensitive_boundingbox(ext::FontExtent, font::FTFont)
     r = rightinkbound(ext)
     b = descender(font)
     t = ascender(font)
-    return FRect2D((l, b), (r - l, t - b))
+    return Rect2f((l, b), (r - l, t - b))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -102,7 +102,7 @@ function FontExtent(fontmetric::FreeType.FT_Glyph_Metrics, scale::Integer)
 end
 
 function bearing(extent::FontExtent)
-    return Vec2f0(extent.horizontal_bearing[1],
+    return Vec2f(extent.horizontal_bearing[1],
                   -(extent.scale[2] - extent.horizontal_bearing[2]))
 end
 
@@ -115,7 +115,7 @@ end
 
 function boundingbox(extent::FontExtent)
     mini = bearing(extent)
-    return Rect2D(mini, Vec2f0(extent.scale))
+    return Rect2(mini, Vec2f(extent.scale))
 end
 
 mutable struct FTFont
@@ -176,10 +176,10 @@ function kerning(c1::Char, c2::Char, face::FTFont)
     kerning2d = Ref{FreeType.FT_Vector}()
     err = FT_Get_Kerning(face, i1, i2, FreeType.FT_KERNING_DEFAULT, kerning2d)
     # Can error if font has no kerning! Since that's somewhat expected, we just return 0
-    err != 0 && return Vec2f0(0)
+    err != 0 && return Vec2f(0)
     # 64 since metrics are in 1/64 units (units to 26.6 fractional pixels)
     divisor = 64
-    return Vec2f0(kerning2d[].x / divisor, kerning2d[].y / divisor)
+    return Vec2f(kerning2d[].x / divisor, kerning2d[].y / divisor)
 end
 
 function get_extent(face::FTFont, char::Char)


### PR DESCRIPTION
Switch to new GeometryBasics type names from JuliaGeometry/GeometryBasics.jl#97.