### PR TITLE
Support per char background color

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,7 +170,8 @@ renderstring!(
 renderstring!(zeros(UInt8, 20, 100), "helgo", face, 10, 25, 80)
 for str in ("helgo", collect("helgo"))
     fcolor = [RGB{Float32}(rand(3)...) for _ ∈ 1:length(str)]
-    renderstring!(zeros(RGB{Float32}, 20, 100), str, face, 10, 0, 0; fcolor = fcolor)
+    gcolor = [RGB{Float32}(rand(3)...) for _ ∈ 1:length(str)]
+    renderstring!(zeros(RGB{Float32}, 20, 100), str, face, 10, 0, 0; fcolor = fcolor, gcolor = gcolor)
 end
 
 # Find fonts


### PR DESCRIPTION
@SimonDanisch, I also need setting the per char background color for drawing `UnicodePlots` colorbars gradients:

**pr**
![foo_ok](https://user-images.githubusercontent.com/13423344/159797263-6df1f7e0-691e-4e82-a15b-172714a6d925.png)

**master**
![foo](https://user-images.githubusercontent.com/13423344/159797249-b36ed668-ad47-4c74-932a-1fb679f5f388.png)

In order not to break the current, I've named it `gcolor` as opposed to `bcolor` for the whole ~~image~~ row background color.

I hope this won't break `Makie`, but I'm not certain of it atm, how can I test this ?