### PR TITLE
Glyph indices

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -5,18 +5,18 @@ iter_or_array(x::AbstractArray) = x
 iter_or_array(x::Union{Mat, StaticVector}) = repeated(x)
 
 
-function metrics_bb(char::Char, font::FTFont, pixel_size)
-    extent = get_extent(font, char) .* Vec2f(pixel_size)
+function metrics_bb(glyph, font::FTFont, pixel_size)
+    extent = get_extent(font, glyph) .* Vec2f(pixel_size)
     return boundingbox(extent), extent
 end
 
-function boundingbox(char::Char, font::FTFont, pixel_size)
-    bb, extent = metrics_bb(char, font, pixel_size)
+function boundingbox(glyph, font::FTFont, pixel_size)
+    bb, extent = metrics_bb(glyph, font, pixel_size)
     return bb
 end
 
-function glyph_ink_size(char::Char, font::FTFont, pixel_size)
-    bb, extent = metrics_bb(char, font, pixel_size)
+function glyph_ink_size(glyph, font::FTFont, pixel_size)
+    bb, extent = metrics_bb(glyph, font, pixel_size)
     return widths(bb)
 end
 

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -2,7 +2,7 @@
 function load_glyph(face::FTFont, glyph)
     gi = glyph_index(face, glyph)
     err = FT_Load_Glyph(face, gi, FT_LOAD_RENDER)
-    check_error(err, "Could not load char to render.")
+    check_error(err, "Could not load glyph $(repr(glyph)) from $(face) to render.")
 end
 
 function loadglyph(face::FTFont, glyph, pixelsize::Integer)

--- a/src/rendering.jl
+++ b/src/rendering.jl
@@ -1,24 +1,25 @@
 
-function loadchar(face::FTFont, c::Char)
-    err = FT_Load_Char(face, c, FT_LOAD_RENDER)
+function load_glyph(face::FTFont, glyph)
+    gi = glyph_index(face, glyph)
+    err = FT_Load_Glyph(face, gi, FT_LOAD_RENDER)
     check_error(err, "Could not load char to render.")
 end
 
-function loadglyph(face::FTFont, c::Char, pixelsize::Integer)
+function loadglyph(face::FTFont, glyph, pixelsize::Integer)
     set_pixelsize(face, pixelsize)
-    loadchar(face, c)
-    glyph = unsafe_load(face.glyph)
-    @assert glyph.format == FreeType.FT_GLYPH_FORMAT_BITMAP
-    return glyph
+    load_glyph(face, glyph)
+    gl = unsafe_load(face.glyph)
+    @assert gl.format == FreeType.FT_GLYPH_FORMAT_BITMAP
+    return gl
 end
 
-function renderface(face::FTFont, c::Char, pixelsize::Integer)
-    glyph = loadglyph(face, c, pixelsize)
-    return glyphbitmap(glyph.bitmap), FontExtent(glyph.metrics)
+function renderface(face::FTFont, glyph, pixelsize::Integer)
+    gl = loadglyph(face, glyph, pixelsize)
+    return glyphbitmap(gl.bitmap), FontExtent(gl.metrics)
 end
 
-function extents(face::FTFont, c::Char, pixelsize::Integer)
-    return FontExtent(loadglyph(face, c, pixelsize).metrics)
+function extents(face::FTFont, glyph, pixelsize::Integer)
+    return FontExtent(loadglyph(face, glyph, pixelsize).metrics)
 end
 
 function glyphbitmap(bitmap::FreeType.FT_Bitmap)

--- a/src/types.jl
+++ b/src/types.jl
@@ -173,9 +173,9 @@ function set_pixelsize(face::FTFont, size::Integer)
     return size
 end
 
-function kerning(c1::Char, c2::Char, face::FTFont)
-    i1 = FT_Get_Char_Index(face, c1)
-    i2 = FT_Get_Char_Index(face, c2)
+function kerning(glyphspec1, glyphspec2, face::FTFont)
+    i1 = glyph_index(face, glyphspec1)
+    i2 = glyph_index(face, glyphspec2)
     kerning2d = Ref{FreeType.FT_Vector}()
     err = FT_Get_Kerning(face, i1, i2, FreeType.FT_KERNING_DEFAULT, kerning2d)
     # Can error if font has no kerning! Since that's somewhat expected, we just return 0

--- a/src/types.jl
+++ b/src/types.jl
@@ -211,7 +211,7 @@ function internal_get_extent(face::FTFont, glyphspec)
     If that happens, all glyph metrics are incorrect. We avoid this by using the normalized space.
     =#
     err = FT_Load_Glyph(face, gi, FT_LOAD_NO_SCALE)
-    check_error(err, "Could not load char to get extent.")
+    check_error(err, "Could not load glyph $(repr(glyphspec)) from $(face) to get extent.")
     # This gives us the font metrics in normalized units (0, 1), with negative
     # numbers interpreted as an offset
     return FontExtent(unsafe_load(face.glyph).metrics, Float32(face.units_per_EM))


### PR DESCRIPTION
This PR changes the base glyph representation to a UInt64 index, which can directly pick a glyph out of a font without the unicode char detour. This allows the methods to work for special scenarios like in MathTeXEngine.jl