### PR TITLE
Reduce dependencies by using `GeometryBasicsCore`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,13 @@ version = "0.10.0"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FreeType = "b38be410-82b0-50bf-ab77-7b57e271db43"
-GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+GeometryBasicsCore = "609001ca-df33-43ad-af5e-98eca4304ed0"
 
 [compat]
 ColorVectorSpace = "0.8, 0.9"
 Colors = "0.11, 0.12"
 FreeType = "4"
-GeometryBasics = "0.4.1"
+GeometryBasicsCore = "1"
 julia = "1"
 
 [extras]

--- a/src/FreeTypeAbstraction.jl
+++ b/src/FreeTypeAbstraction.jl
@@ -1,23 +1,22 @@
 module FreeTypeAbstraction
 
-using FreeType, Colors, ColorVectorSpace, GeometryBasics
+using FreeType, Colors, ColorVectorSpace, GeometryBasicsCore
 using Base.Iterators: Repeated, repeated
 import Base: /, *, ==
+
 import Base.Broadcast: BroadcastStyle, Style, broadcasted
-using GeometryBasics: StaticVector
+import GeometryBasicsCore: StaticVector
 
 include("types.jl")
 include("findfonts.jl")
 include("layout.jl")
 include("rendering.jl")
 
-export FTFont
-export newface
-export renderface
-export FontExtent
-export kerning
-export renderstring!
-export findfont
+# types
+export FTFont, FontExtent
+
+# methods
+export newface, renderface, kerning, renderstring!, findfont
 
 const valid_fontpaths = String[]
 fontpaths() = valid_fontpaths

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,11 @@
 ENV["FREETYPE_ABSTRACTION_FONT_PATH"] = @__DIR__  # coverage
 
-using FreeTypeAbstraction, Colors, ColorVectorSpace, GeometryBasics
-using GeometryBasics: Vec2f
-import FreeTypeAbstraction as FA
-using FreeType
+using FreeTypeAbstraction, FreeType
+using Colors, ColorVectorSpace, GeometryBasicsCore
 using Test
+
+import GeometryBasicsCore: Vec2f
+import FreeTypeAbstraction as FA
 
 @testset "init and done" begin
     @test_throws ErrorException FA.ft_init()
@@ -290,7 +291,7 @@ end
         bb, extent = FA.metrics_bb(glyph, face, 64)
         bb2 = FA.boundingbox(glyph, face, 64)
         @test bb == bb2
-        w = GeometryBasics.widths(bb2)
+        w = widths(bb2)
         @test w == FA.glyph_ink_size(glyph, face, 64)
     end
 end


### PR DESCRIPTION
Fix https://github.com/JuliaGraphics/FreeTypeAbstraction.jl/issues/74.

Needs https://github.com/JuliaGeometry/GeometryBasics.jl/pull/179.