### PR TITLE
Add locking mechanism around FT_New_Face and FT_Done_Face

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: 4
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,3 +294,11 @@ end
         @test w == FA.glyph_ink_size(glyph, face, 64)
     end
 end
+
+@testset "threaded face creation" begin
+    # this should just not crash
+    Threads.@threads for i in 1:10_000
+        FreeTypeAbstraction.newface(joinpath(@__DIR__, "hack_regular.ttf"))
+    end
+    GC.gc()
+end


### PR DESCRIPTION
FreeType has been showing up in threading issues when using Makie. When checking the FreeType docs, I found that when using a single library object, one should lock on `FT_New_Face` and `FT_Done_Face`, which is implemented here. I tried to follow the best practices for locks in finalizers and took the implementation from this PR https://github.com/JuliaIO/HDF5.jl/pull/1049/files which got it from here https://docs.julialang.org/en/v1/manual/multi-threading/#Safe-use-of-Finalizers

I also added an ENV variable setting the number of threads in CI tests to 4 so that the test (which is very basic and could probably be improved) should have multiple threads to run on. The test doesn't ensure that, but I didn't quickly find an easy way to do it except the unmaintained (by now probably outdated) library https://github.com/JuliaTesting/PerformanceTestTools.jl

This does not solve the problem of using FT_Face objects from multiple threads but I'll leave that for a future implementation. Probably, those objects should each get their own lock.