### PR TITLE
Better font-finding heuristics, with a shortcut and a few caches.

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,4 +3,9 @@ function _precompile_()
     @assert precompile(Tuple{typeof(findfont),String})   # time: 0.12886831
     @assert precompile(Tuple{typeof(try_load),String})   # time: 0.033520337
     @assert precompile(Tuple{typeof(renderface),FTFont,Char,Int64})   # time: 0.019107351
+    # Populate the font info cache
+    __init__()
+    for folder in fontpaths()
+        map(font_info, readdir(folder, join=true))
+    end
 end


### PR DESCRIPTION
I initially started looking at this package when I found that it doesn't always look in the right directories for fonts (see #82). However, I recently found that the heuristic for font finding itself is both slow (#67) and a bit dodgy (#83).

So, I've gone through the font-finding code and made a few changes:
- The scoring heuristic takes a few more factors into account
  - Earlier components of a search string are now weighted slightly higher (e.g. the `plex` in `ibm plex sans italic` is worth more than `sans`)
  - Particular regular styles will be picked over others (e.g. `regular` over `medium`)
  - Certain font formats are prioritised (e.g. `otf` over `pfb`)
- ~~Introduced a considered shortcut when scoring each font file~~
  - ~~The list of matching font-file is pre-sorted according to matches of the search string in the font file name~~
  - ~~We calculate the _maximum possible_ family and style score given the search string~~
  - ~~We return the current best font early when:~~
    - ~~We have found a font that maximum score~~
    - ~~We have seen more than twice as many fonts as the last font with the maximum score seen~~
- Introduced a few (runtime) caches
  - A cache of the font file names, without the extension, as lowercase
  - A cache of the family, style, and extension of font files
  - A cache of the resolved font for given searches (invalidated by directory modification times)

From the test that I've performed locally, this batch of changes results in faster, better initial lookups, and faster (again) subsequent lookups.

-----

Here are some test results on my machine:

| Search string             | Current time | PR time | Current result (family, style)      | PR result                            |
|---------------------------|--------------|---------|-------------------------------------|--------------------------------------|
| ibm plex sans bold italic | 1.5s         | 0.06s   | AlegreyaSans-BoldItalic, Bold       | IBM Plex Sans, Bold Italic           |
| ibm sans                  | 1.5s         | 0.04s   | IBM Plex Sans, Regular              | (same)                               |
| sans                      | 1.5s         | 0.02s   | KpSans, Regular                     | DejaVu Sans, Book                    |
| hack                      | 1.5s         | 0.02s   | Hack, Regular                       | (same)                               |
| computer modern           | 1.5s         | 0.03s   | Computer Modern, Roman              | Computer Modern, Medium              |
| schoolbook                | 1.5s         | 0.03s   | Century Schoolbook L, Roman         | Adobe New Century Schoolbook, Medium |
| medium euler              | 1.5s         | 0.08s   | Alegreya-Medium, Medium             | Euler, Medium                        |
| bold slanted roman        | 1.5s         | 0.04s   | Latin Modern Roman Slanted, 10 Bold | (same)                               |

Subsequent identical searches take ~0.0002s.

If more people could perform adversarial (but not pathological) tests with this scheme, that would be much appreciated.