### PR TITLE
Use mmapping to avoid unicode issues on windows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FreeType = "b38be410-82b0-50bf-ab77-7b57e271db43"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [compat]
 BaseDirs = "1"
@@ -15,6 +16,7 @@ ColorVectorSpace = "0.8, 0.9, 0.10, 0.11"
 Colors = "0.11, 0.12, 0.13"
 FreeType = "4"
 GeometryBasics = "0.4.1, 0.5"
+Mmap = "1"
 julia = "1.6"
 
 [extras]

--- a/src/FreeTypeAbstraction.jl
+++ b/src/FreeTypeAbstraction.jl
@@ -6,6 +6,7 @@ import Base: /, *, ==, @lock
 import Base.Broadcast: BroadcastStyle, Style, broadcasted
 using GeometryBasics: StaticVector
 using BaseDirs
+import Mmap
 
 include("types.jl")
 include("findfonts.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -296,6 +296,15 @@ end
     end
 end
 
+@testset "Unicode in path" begin
+    mktempdir() do dir
+        path = joinpath(dir, "𝓜𝔂 𝔽𝕒𝕟𝕔𝕪 𝐅𝐨𝐧𝐭 🅵🅸🅻🅴.ttf")
+        cp(joinpath(@__DIR__, "hack_regular.ttf"), path)
+        f = FreeTypeAbstraction.FTFont(path)
+        @test repr(f) == "FTFont (family = Hack, style = Regular)"
+    end
+end
+
 @testset "Thread safety" begin
     mktempdir() do dir
         n = 100


### PR DESCRIPTION
FreeType uses a method to open files on windows that seems to be incompatible with unicode, see https://stackoverflow.com/questions/10075032/can-freetype-functions-accept-unicode-filenames. Another option then is to use `FT_New_Memory_Face` which I've done here. I could have also read the file into memory but it seemed to me mmapping would be a bit lighter on RAM? Also, I'm not 100% sure if the way I immediately close the io after mmapping is correct, or if it should stay open for the lifetime of the mmapped array.

Fixes #85 