### PR TITLE
we need a lock for accessing the cache as well

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -203,8 +203,10 @@ end
 function get_extent(face::FTFont, glyphspec)
     gi = glyph_index(face, glyphspec)
     if use_cache(face)
-        get!(get_cache(face), gi) do
-            return internal_get_extent(face, gi)
+        lock(face.lock) do
+            get!(get_cache(face), gi) do
+                return internal_get_extent(face, gi)
+            end
         end
     else
         return internal_get_extent(face, gi)


### PR DESCRIPTION
I notice the other operations on `font.lock` are more fine grained, not sure if  that's worth for the cache as well ;) 